### PR TITLE
Add documentation and example for server side paging. Switch to hash URLs.

### DIFF
--- a/app/Server/Server.component.html
+++ b/app/Server/Server.component.html
@@ -1,0 +1,41 @@
+<div class="row">
+	<div class="col-sm-12">
+		<h2 class="page-header">Server</h2>
+
+		<h3>1. Implement <code>IDataPipeService</code> and make it <code>@Injectable</code></h3>
+		<span>The <code>pipe()</code> method can ignore <code>data: Array&lt;any&gt;</code> as it is mainly relevant for client-side paging.
+		The parameter <code>tableState: ITableState</code> has values <code>ITableState.pagination.start</code> and <code>ITableState.pagination.pageSize</code>
+		that should be used for retrieving paginated data from the server.
+		</span>
+
+		<div class="alert alert-info">
+			<i class="fa fa-info-circle"></i>
+			The value <code>ITableState.pagination.totalItemCount</code> should be kept up-to-date.
+			This can either be done by the pipe (e.g. count is constantly growing) or the parent component
+			(e.g. count only changes due to user interaction with filter settings).
+        </div>
+		<br />
+
+		<h3>2. Bind an <code>IConfiguration</code> to the table which refers to the custom <code>IDataPipeService</code></h3>
+		<span>
+			The parent component can use <code>DefaultConfiguration.create()</code> to get a fully functional configuration then set <code>IConfiguration.pipeServiceType</code> to the custom pipe.
+		</span>
+		<br />
+
+		<tabset>
+			<tab heading="Display">
+				<div style="padding: 15px;">
+					<server-example></server-example>
+				</div>
+			</tab>
+
+			<tab heading="Html">
+				<code-example content-url="app/Server/ServerExample.component.html" lang="lang-html"></code-example>
+			</tab>
+
+			<tab heading="Typescript">
+				<code-example content-url="app/Server/ServerExample.component.ts" lang="lang-ts"></code-example>
+			</tab>
+		</tabset>
+	</div>
+</div>

--- a/app/Server/Server.component.ts
+++ b/app/Server/Server.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    moduleId: module.id,
+    templateUrl: './Server.component.html'
+})
+export class ServerComponent implements OnInit {
+    constructor() { }
+
+    ngOnInit() { }
+}

--- a/app/Server/ServerExample.component.html
+++ b/app/Server/ServerExample.component.html
@@ -1,0 +1,25 @@
+<table [ptTable]="allCommits" [(ptDisplayArray)]="commits" [ptConfiguration]="configuration" class="table table-bordered table-stripped">
+    <thead>
+        <tr>
+            <th>Sha</th>
+            <th>Name</th>
+            <th>Date</th>
+            <th>Message</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr *ngFor="let commit of commits; let i = index;">
+            <td><code>{{commit.sha | slice:0:6}}</code></td>
+            <td>{{commit.commit.author.name}}</td>
+            <td>{{commit.commit.author.date | date:'shortDate'}}</td>
+            <td>{{commit.commit.message}}</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <td colspan="4">
+                <pt-pagination></pt-pagination>
+            </td>
+        </tr>
+    </tfoot>
+</table>

--- a/app/Server/ServerExample.component.ts
+++ b/app/Server/ServerExample.component.ts
@@ -1,0 +1,50 @@
+
+import { Component, OnInit, Injectable } from '@angular/core';
+import { Person } from './../MockData/Person.class';
+import { IConfiguration, DefaultConfiguration, IDataPipeService, ITableState } from 'ng2-power-table/ng2-power-table';
+import { Http } from '@angular/http';
+
+@Injectable()
+class GithubDataPipe implements IDataPipeService {
+    constructor(private http : Http) {}
+
+    pipe(data: Array<any>, tableState: ITableState, configuration: IConfiguration): Promise<Array<any>> {
+        this.http.get('https://api.github.com/repos/hoveytech/ng2-power-table/stats/commit_activity')
+            .toPromise()
+            .then(response => {
+                let totalItemCount = 0;
+                let weeks = response.json();
+                for(var week of weeks) {
+                    totalItemCount += week.total;
+                }
+                tableState.pagination.totalItemCount = totalItemCount;
+            });
+
+        let perPage = tableState.pagination.pageSize;
+        let page = Math.ceil(tableState.pagination.start / perPage) + 1; // github uses 1-indexing
+        let getCommits = 'https://api.github.com/repos/hoveytech/ng2-power-table/commits';
+        getCommits += `?page=${page}&per_page=${perPage}`;
+        return this.http.get(getCommits)
+            .toPromise()
+            .then(response => response.json() as Object[]);
+    }
+}
+
+@Component({
+    moduleId: module.id,
+    selector: 'server-example',
+    templateUrl: './ServerExample.component.html',
+    providers: [GithubDataPipe]
+})
+export class ServerExampleComponent {
+    public allCommits: Array<any>; // unused
+    public commits: Array<any>;
+    public configuration: IConfiguration;
+
+    constructor() {
+        this.allCommits = [];
+        this.commits = [];
+        this.configuration = DefaultConfiguration.create();
+        this.configuration.pipeServiceType = GithubDataPipe;
+    }
+}

--- a/app/app.component.ts
+++ b/app/app.component.ts
@@ -19,6 +19,9 @@ import { SortingComponent } from './Sorting/Sorting.component';
 import { SortingExampleComponent } from './Sorting/SortingExample.component';
 import { PagingComponent } from './Paging/Paging.component';
 import { PagingExampleComponent } from './Paging/PagingExample.component';
+import { ServerComponent } from './Server/Server.component';
+import { ServerExampleComponent } from './Server/ServerExample.component';
+
 
 export var Ng2PowerTableComponents : Array<any> = [
     CodeExampleComponent,
@@ -30,6 +33,8 @@ export var Ng2PowerTableComponents : Array<any> = [
     SortingExampleComponent,
     PagingComponent,
     PagingExampleComponent,
+    ServerComponent,
+    ServerExampleComponent,
 
     AppComponent,
     LoadingFrameComponent

--- a/app/app.routes.ts
+++ b/app/app.routes.ts
@@ -4,15 +4,19 @@ import { Routes, RouterModule } from '@angular/router';
 import { BasicComponent } from './Basics/Basic.component';
 import { SortingComponent } from './Sorting/Sorting.component';
 import { PagingComponent } from './Paging/Paging.component';
+import { ServerComponent } from './Server/Server.component';
+
 
 const appRoutes: Routes = [
   { path: '', component: BasicComponent },
   { path: 'sorting', component: SortingComponent },
-  { path: 'paging', component: PagingComponent }
+  { path: 'paging', component: PagingComponent },
+  { path: 'server', component: ServerComponent }
+
 ];
 
 export const appRoutingProviders: any[] = [
 
 ];
 
-export const routing: ModuleWithProviders = RouterModule.forRoot(appRoutes);
+export const routing: ModuleWithProviders = RouterModule.forRoot(appRoutes, {useHash: true});


### PR DESCRIPTION
Added example custom async IDataPipeService using Github public APIs to display commits for this project.
Changed router to use hash URLs to avoid 404 when hosted on GitHub pages.

Not sure I quite have the Bower, Gulp, Jekyll build chain figured out yet (also might have conflicting global versions that's causing slight whitespace differences), so this PR just has the TypeScript and HTML files so you can build it proper.